### PR TITLE
Fix Linux build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ FloodForge.exe
 FloodForge
 FloodForge.zip
 
+build/obj
+
 TODO.md
 
 .vscode/

--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ Use this if you are editing the code and need to quickly test
 > Linux builds are untested, they may not work.
 
 Requirements:
-- [GTK](https://www.gtk.org)
+- [GTK3](https://www.gtk.org)
+- GLFW3
+- pkg-config
+- Make
 
-`./build/World.sh`
+```bash
+build/World.sh
+```
 
 ## Custom Themes
 To create a custom theme, you need to modify the file `assets/theme.txt`.

--- a/build/World.sh
+++ b/build/World.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
-
-clear
-
-g++ src/*.cpp src/world/*.cpp src/font/*.cpp --std=c++17 -I"include/" -L"lib/GLFW/" -o FloodForge -lglfw3 -lgdi32 -lopengl32 -luser32 -lcomdlg32
+make -f build/world.mk
 
 if [ $? -eq 0 ]; then
-    clear
-    ./FloodForge
+    build/FloodForge
 else
     echo "Compilation failed."
 fi

--- a/build/world.mk
+++ b/build/world.mk
@@ -1,0 +1,34 @@
+# note from pkhead:
+# consider using an actual build system
+# meson or cmake
+# batch files/shell scripts and makefiles are difficult to use and to make platform/compiler-agnostic.
+#
+# TODO: couldn't figure out how to use static glfw from the libs folder. (usually, i just include glfw source as a submodule)
+#		so right now, it just uses glfw from the package manager.
+
+CXX=c++
+
+# list of all cpp source files
+SOURCES=$(wildcard src/font/*.cpp) $(wildcard src/math/*.cpp) $(wildcard src/world/*.cpp) $(wildcard src/*.cpp)
+
+CPPFLAGS=--std=c++17
+INCLUDES=-I"include/" $(shell pkg-config --cflags glfw3) $(shell pkg-config --cflags gtk+-3.0)
+LIBS=$(shell pkg-config --static --libs glfw3) $(shell pkg-config --libs gtk+-3.0) -lGL
+
+# list of all .o files associated with source .cpp files
+OBJS=$(addprefix build/obj/, $(shell realpath --relative-to src $(SOURCES:%.cpp=%.o)))
+
+# build an .o file from a .cpp file
+build/obj/%.o: src/%.cpp
+	@mkdir -p $(dir $@)
+	@echo [CXX] $<
+	@$(CXX) -c $(CPPFLAGS) $(INCLUDES) $< -o $@
+
+# link all .o files to build FloodForge executable
+build/FloodForge: $(OBJS)
+	@echo [LNK] $@
+	@$(CXX) -o $@ $(OBJS) $(LIBS)
+
+.PHONY: clean
+clean:
+	rm -rf build/obj

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
+#include <cstring>
 
 #define M_PI   3.141592653589
 #define M_PI_2 1.570796326795
@@ -291,7 +292,7 @@ bool verifyBox(std::string text) {
 #include <iostream>
 #include <string>
 
-std::string OpenNewFileDialog(std::string types) {
+std::string OpenNewFileDialog(const std::string& types) {
     GtkWidget *dialog;
     GtkFileFilter *filter;
     GtkFileChooserAction action = GTK_FILE_CHOOSER_ACTION_OPEN;
@@ -325,7 +326,7 @@ std::string OpenNewFileDialog() {
     return OpenNewFileDialog("*.level");
 }
 
-std::string OpenFileDialog(std::string types) {
+std::string OpenFileDialog(const std::string& types) {
     return OpenNewFileDialog(types);
 }
 


### PR DESCRIPTION
Linux build wasn't working, so I did several things to fix it:
- Added makefile `build/world.mk`
- Updated `build/World.sh` to run this makefile (and removed clear calls because I found it annoying).
- Updated some source code because of some previously unresolved function references.

If the GTK3 dependency was removed, and the program was linked with windows DLLs, it would work with Msys2 MinGW. Currently, this makefile only works on Linux.

I couldn't figure out how to make it use the static glfw from the lib folder. (Usually, I just include the GLFW source as a submodule). So I just made it use glfw from the package manager, meaning it only works if the user has it installed through it.

Also, I think you should consider using an actual build system, namely Meson or CMake. Batch files, shell scripts, and makefiles are more difficult to write and to make platform/compiler-agnostic.