### PR TITLE
Level Regex Fix

### DIFF
--- a/src/world/MenuItems.cpp
+++ b/src/world/MenuItems.cpp
@@ -218,7 +218,7 @@ void MenuItems::init(Window *window) {
 				return;
 			}
 
-			Popups::addPopup((new FilesystemPopup(window, std::regex("(([^._-]+)_[a-zA-Z0-9]+\\.txt)|(gate_([^._-]+)_([^._-]+)\\.txt)"), "xx_a01.txt",
+			Popups::addPopup((new FilesystemPopup(window, std::regex("((?!.*_settings)(?=.+_.+).+\\.txt)|(gate_([^._-]+)_([^._-]+)\\.txt)"), "xx_a01.txt",
 				[&](std::set<std::filesystem::path> paths) {
 					if (paths.empty()) return;
 


### PR DESCRIPTION
(Turned this issue into a PR)

Basically the existing Regex here doesn't match level files such as hr_layers_of_reality or warf_b01_future, as well as a bunch of my rooms, basically anything that uses multiple underscores

Suggesting something like this maybe, doesn't include anything with _settings, requires it to have at least one *_* format, and have a .txt extension
((?!.*_settings)(?=.+_.+).+\\.txt)|(gate_([^._-]+)_([^._-]+)\\.txt)

though I'm pretty bad at regex and there might be a case I've missed, let me know if you see any issues with this