### PR TITLE
Option to Sync Dev & Canon

### DIFF
--- a/src/world/Globals.cpp
+++ b/src/world/Globals.cpp
@@ -21,7 +21,8 @@ namespace EditorState {
 	int roomPositionType = CANON_POSITION;
 	bool visibleLayers[] = { true, true, true };
 	bool visibleDevItems = false;
-	
+	bool syncDevAndCanon = true;
+
 	Region region;
 
 	int selectingState = 0;

--- a/src/world/Globals.hpp
+++ b/src/world/Globals.hpp
@@ -47,6 +47,7 @@ namespace EditorState {
 	extern int roomPositionType;
 	extern bool visibleLayers[LAYER_COUNT];
 	extern bool visibleDevItems;
+	extern bool syncDevAndCanon;
 	
 	extern Region region;
 

--- a/src/world/MenuItems.cpp
+++ b/src/world/MenuItems.cpp
@@ -400,6 +400,14 @@ void MenuItems::init(Window *window) {
 		}
 	);
 
+	addButton("Sync Dev & Canon: On")
+	.OnLeftPress(
+		[window](Button *button) {
+			EditorState::syncDevAndCanon = !EditorState::syncDevAndCanon;
+			button->Text(EditorState::syncDevAndCanon ? "Sync Dev & Canon: On" : "Sync Dev & Canon: Off");
+		}
+	);
+
 	// addButton("Change Region Acronym").OnLeftPress(
 	// 	[window](Button *button) {
 	// 		if (EditorState::region.acronym == "") {

--- a/src/world/main.cpp
+++ b/src/world/main.cpp
@@ -233,7 +233,7 @@ void updateOriginalControls() {
 
 					roomPosition.add(offset);
 
-					if (EditorState::window->modifierPressed(GLFW_MOD_ALT)) {
+					if (EditorState::syncDevAndCanon || EditorState::window->modifierPressed(GLFW_MOD_ALT)) {
 						room2->moveBoth();
 					}
 				}
@@ -361,7 +361,7 @@ void updateFloodForgeControls() {
 					}
 
 					roomPosition.add(offset);
-					if (EditorState::window->modifierPressed(GLFW_MOD_ALT)) {
+					if (EditorState::syncDevAndCanon || EditorState::window->modifierPressed(GLFW_MOD_ALT)) {
 						room2->moveBoth();
 					}
 				}


### PR DESCRIPTION
<img width="364" height="28" alt="image" src="https://github.com/user-attachments/assets/3e6becbf-1393-4555-a598-d92ab9c96980" />

Just adds a button to toggle keeping rooms between the dev and canon views in sync, same as keeping alt held down the whole time

Think it should be useful, at least personally 99% of my rooms are positioned the same in the dev view and canon view