### PR TITLE
Khymera_Sky's Fifth Merge (Update 1)

### DIFF
--- a/FloodForge/src/droplet/DropletWindow.cs
+++ b/FloodForge/src/droplet/DropletWindow.cs
@@ -92,8 +92,11 @@ public static class DropletWindow {
 
 	// REVIEW - add a separate class containing camera data & controls, so that camera controls are unified?
 	private static void UpdateCamera() {
-		bool isHoveringPopup = Mouse.Disabled;
+		bool isHoveringPopup = PopupManager.Windows.Any(x => x.InteractBounds().Inside(Mouse.Pos));
+
 		float scrollY = -Mouse.Scroll;
+		if (isHoveringPopup)
+			scrollY = 0f;
 		float zoom = MathF.Pow(1.25f, scrollY);
 
 		if (float.IsNaN(cameraOffset.x) || float.IsNaN(cameraOffset.y)) {

--- a/FloodForge/src/droplet/DropletWindow.cs
+++ b/FloodForge/src/droplet/DropletWindow.cs
@@ -2093,7 +2093,7 @@ public static class DropletWindow {
 		for (int i = 0; i < Room.data.cameras.Count; i++) {
 			if (i > 0) project.Append(", ");
 			RoomData.Camera c = Room.data.cameras[i];
-			project.Append($"point({(c.position.x + 12.0f) * 20.0f:F1}, {(c.position.y + 3.0f) * 20.0f:F1})");
+			project.Append($"point({c.position.x + 240.0f:F1}, {c.position.y + 60.0f:F1})"); // 240 = 12 * 20, 60 = 3 * 20 (the additional tile borders * 20)
 		}
 		project.Append("], #selectedCamera: 0, #quads: [");
 

--- a/FloodForge/src/droplet/DropletWindow.cs
+++ b/FloodForge/src/droplet/DropletWindow.cs
@@ -2244,7 +2244,7 @@ public static class DropletWindow {
 								if (paths.Length != 1) return;
 
 								ExportProject(paths[0]);
-							}).Filter(FilesystemPopup.SelectionType.Folder).Hint("Data/LevelEditorProjects")
+							}).Filter(FilesystemPopup.SelectionType.Folder).Hint("Data/LevelEditorProjects").ButtonText("Export")
 						);
 					}),
 

--- a/FloodForge/src/droplet/DropletWindow.cs
+++ b/FloodForge/src/droplet/DropletWindow.cs
@@ -2024,14 +2024,24 @@ public static class DropletWindow {
 	private static void ExportProject(string path) {
 		string fileName = Path.Combine(path, Room.name + ".txt");
 		StringBuilder project = new StringBuilder();
+		StringBuilder tlMatrix = new StringBuilder();
 
 		project.Append("[");
+		tlMatrix.Append("[");
+
 		for (int x = -12; x < Room.width + 12; x++) {
-			if (x != -12) project.Append(", ");
+			if (x != -12) {
+				project.Append(", ");
+				tlMatrix.Append(", ");
+			}
 
 			project.Append("[");
+			tlMatrix.Append("[");
 			for (int y = -3; y < Room.height + 5; y++) {
-				if (y != -3) project.Append(", ");
+				if (y != -3) {
+					project.Append(", ");
+					tlMatrix.Append(", ");
+				}
 
 				uint geo = Room.GetTile(x, y);
 				int solidA = 0;
@@ -2064,12 +2074,16 @@ public static class DropletWindow {
 				project.Append($"[[{solidA}, [{string.Join(", ", flags)}]], ");
 				project.Append($"[{((geo & 512) > 0 ? "1" : "0")}, []], ");
 				project.Append("[0, []]]");
+
+				tlMatrix.Append("[[#tp: \"default\", #Data: 0],[#tp: \"default\", #Data: 0],[#tp: \"default\", #Data: 0]]");
 			}
 			project.Append("]");
+			tlMatrix.Append("]");
 		}
 		project.Append("]\n");
+		tlMatrix.Append("]");
 
-		project.AppendLine("[#lastKeys: [], #Keys: [], #workLayer: 1, #lstMsPs: point(0, 0), #tlMatrix: [], #defaultMaterial: \"Standard\", #toolType: \"material\", #toolData: \"Big Metal\", #tmPos: point(1, 1), #tmSavPosL: [], #specialEdit: 0]");
+		project.AppendLine($"[#lastKeys: [], #Keys: [], #workLayer: 1, #lstMsPs: point(0, 0), #tlMatrix: {tlMatrix}, #defaultMaterial: \"Standard\", #toolType: \"material\", #toolData: \"Big Metal\", #tmPos: point(1, 1), #tmSavPosL: [], #specialEdit: 0]");
 		project.AppendLine("[#lastKeys: [], #Keys: [], #lstMsPs: point(0, 0), #effects: [], #emPos: point(1, 1), #editEffect: 0, #selectEditEffect: 0, #mode: \"createNew\", #brushSize: 5]");
 		project.AppendLine($"[#pos: point(0, 0), #rot: 0, #sz: point({Room.width}, {Room.height}), #col: 1, #Keys: [#m1: 0, #m2: 0, #w: 0, #a: 0, #s: 0, #d: 0, #r: 0, #f: 0, #z: 0, #m: 0], #lastKeys: [#m1: 0, #m2: 0, #w: 0, #a: 0, #s: 0, #d: 0, #r: 0, #f: 0, #z: 0, #m: 0], #lastTm: 0, #lightAngle: 180, #flatness: 1, #lightRect: rect(1000, 1000, -1000, -1000), #paintShape: \"pxl\"]");
 		project.AppendLine($"[#timeLimit: 4800, #defaultTerrain: {(Room.data.enclosedRoom ? "1" : "0")}, #maxFlies: 10, #flySpawnRate: 50, #lizards: [], #ambientSounds: [], #music: \"NONE\", #tags: [], #lightType: \"Static\", #waterDrips: 1, #lightRect: rect(0, 0, 1040, 800), #Matrix: []]");

--- a/FloodForge/src/droplet/DropletWindow.cs
+++ b/FloodForge/src/droplet/DropletWindow.cs
@@ -444,6 +444,9 @@ public static class DropletWindow {
 			selectedTool = (GeometryTool)tool;
 		}
 
+		if (Mouse.Disabled || PopupManager.Windows.Any(x => x.InsideBoundsOrIncluder(Mouse.Pos)))
+			return;
+
 		if (showMousePosition) {
 			Immediate.Color(Color.White);
 			UI.font.Write($"x:{mouseTile.x} y:{mouseTile.y}", mouseTile.x, -mouseTile.y + 1, 0.6f);

--- a/FloodForge/src/popups/FilesystemPopup.cs
+++ b/FloodForge/src/popups/FilesystemPopup.cs
@@ -12,6 +12,8 @@ public class FilesystemPopup : Popup {
 	protected bool allowMultiple = false;
 	protected SelectionType typeFilter = SelectionType.File;
 	protected string hint = "";
+	protected string buttonText = "Open";
+	protected float buttonWidth = 0.1f;
 
 	protected string? search = null;
 	protected string? newDirectory = null;
@@ -113,6 +115,12 @@ public class FilesystemPopup : Popup {
 
 	public FilesystemPopup Hint(string hint) {
 		this.hint = hint;
+		return this;
+	}
+
+	public FilesystemPopup ButtonText(string text) {
+		this.buttonText = text;
+		this.buttonWidth = UI.font.Measure(text, 0.03f).x;
 		return this;
 	}
 
@@ -486,7 +494,7 @@ public class FilesystemPopup : Popup {
 
 		float left = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0.21f : 0.14f;
 
-		if (UI.TextButton("Open", new Rect(this.bounds.x1 - 0.11f, this.bounds.y0 + 0.06f, this.bounds.x1 - 0.01f, this.bounds.y0 + 0.01f), new UI.TextButtonMods() { disabled = this.selected.Count == 0 && this.typeFilter == SelectionType.File })) {
+		if (UI.TextButton(this.buttonText, new Rect(this.bounds.x1 - 0.02f - this.buttonWidth, this.bounds.y0 + 0.06f, this.bounds.x1 - 0.01f, this.bounds.y0 + 0.01f), new UI.TextButtonMods() { disabled = this.selected.Count == 0 && this.typeFilter == SelectionType.File })) {
 			this.Accept();
 		}
 

--- a/FloodForge/src/popups/FloodforgeConfigPopup.cs
+++ b/FloodForge/src/popups/FloodforgeConfigPopup.cs
@@ -87,7 +87,11 @@ public class FloodforgeConfigPopup : Popup {
 			Immediate.Color(Color.White);
 		}
 
-		Immediate.Color(Color.White);
+		Immediate.Color(Themes.TextWarn);
+		font.Write("NOTE: Settings can't currently be saved.", this.bounds.x0 + 0.01f, settingRect.y1, 0.03f, Font.Align.TopLeft);
+		Immediate.Color(Themes.Text);
+
+		GotoNextSetting();
 		font.Write(this.CameraPanSpeed.settingName, this.bounds.x0 + 0.01f, settingRect.y1, 0.03f, Font.Align.TopLeft);
 		UI.Slider(settingRect, this.CameraPanSpeed.editable, ref this.CameraPanSpeed.ValueRef);
 

--- a/FloodForge/src/popups/Popup.cs
+++ b/FloodForge/src/popups/Popup.cs
@@ -18,6 +18,7 @@ public abstract class Popup {
 	protected Rect minimumResizeBounds;
 	protected Rect? initialBounds;
 	public Vector2 TopLeft => new (this.bounds.x0, this.bounds.y1);
+	public float CollapsedWidth => Math.Min(Math.Max(UI.font.Measure(this.popupTitle, 0.03f).x + 0.12f, 0.25f), this.bounds.x1 - this.bounds.x0);
 
 	protected Rect scaleControlIncluder;
 	protected Rect scaleControlExcluder;
@@ -217,14 +218,12 @@ public abstract class Popup {
 			Immediate.Color(Themes.Popup);
 			UI.ButtonFillRect(this.bounds.x0, this.bounds.y0, this.bounds.x1, this.bounds.y1);
 		}
-		
-		float collapsedWidth = Math.Min(Math.Max(UI.font.Measure(this.popupTitle, 0.03f).x + 0.12f, 0.25f), this.bounds.x1 - this.bounds.x0);
 
 		Immediate.Color(Themes.PopupHeader);
-		UI.ButtonFillRect(this.collapsed ? this.bounds.x1 - collapsedWidth : this.bounds.x0, this.bounds.y1 - 0.05f, this.bounds.x1, this.bounds.y1);
+		UI.ButtonFillRect(this.collapsed ? this.bounds.x1 - this.CollapsedWidth : this.bounds.x0, this.bounds.y1 - 0.05f, this.bounds.x1, this.bounds.y1);
 		if(this.popupTitle != "") {
 			Color textColor = this.collapsed ? Themes.TextDisabled : Themes.Text;
-			UI.font.WriteFormatted(this.popupTitle, this.collapsed ? this.bounds.x1 - collapsedWidth + 0.01f : this.bounds.x0 + 0.01f, this.bounds.y1 - 0.025f, 0.03f, Font.Align.MiddleLeft, textColor);
+			UI.font.WriteFormatted(this.popupTitle, this.collapsed ? this.bounds.x1 - this.CollapsedWidth + 0.01f : this.bounds.x0 + 0.01f, this.bounds.y1 - 0.025f, 0.03f, Font.Align.MiddleLeft, textColor);
 		}
 
 		this.closeButton = new UVRect(this.bounds.x1 - 0.05f, this.bounds.y1 - 0.05f, this.bounds.x1, this.bounds.y1).AtlasUV("cross");
@@ -246,7 +245,7 @@ public abstract class Popup {
 
 		Immediate.Color(this.isHovered ? Themes.BorderHighlight : Themes.Border);
 		if (this.collapsed) {
-			UI.ButtonStrokeRect(this.bounds.x1 - collapsedWidth, this.bounds.y1 - 0.05f, this.bounds.x1, this.bounds.y1);
+			UI.ButtonStrokeRect(this.bounds.x1 - this.CollapsedWidth, this.bounds.y1 - 0.05f, this.bounds.x1, this.bounds.y1);
 		}
 		else {
 			UI.ButtonStrokeRect(this.bounds.x0, this.bounds.y0, this.bounds.x1, this.bounds.y1);
@@ -280,7 +279,7 @@ public abstract class Popup {
 		this.cursorOverrideActive = false;
 	}
 
-	public virtual Rect InteractBounds() => this.collapsed ? new Rect(this.bounds.x0, this.bounds.y1 - 0.05f, this.bounds.x1, this.bounds.y1) : this.bounds;
+	public virtual Rect InteractBounds() => this.collapsed ? new Rect(this.bounds.x1 - this.CollapsedWidth, this.bounds.y1 - 0.05f, this.bounds.x1, this.bounds.y1) : this.bounds;
 
 	public virtual bool InsideBoundsOrIncluder(Vector2 mousePos) => this.InteractBounds().Inside(mousePos) || this.hoverRetained;
 
@@ -322,7 +321,7 @@ public abstract class Popup {
 	public virtual bool IsDragArea(float mouseX, float mouseY) {
 		if (this.resizingWindow)
 			return false;
-		if (mouseX <= this.bounds.x1 - 0.1f && mouseX >= this.bounds.x0 && mouseY <= this.bounds.y1 && mouseY >= this.bounds.y1 - 0.05f) return true;
+		if (mouseX <= this.bounds.x1 - 0.1f && mouseX >= (this.collapsed ? this.bounds.x1 - this.CollapsedWidth : this.bounds.x0) && mouseY <= this.bounds.y1 && mouseY >= this.bounds.y1 - 0.05f) return true;
 
 		return false;
 	}

--- a/FloodForge/src/popups/Popup.cs
+++ b/FloodForge/src/popups/Popup.cs
@@ -282,6 +282,8 @@ public abstract class Popup {
 
 	public virtual Rect InteractBounds() => this.collapsed ? new Rect(this.bounds.x0, this.bounds.y1 - 0.05f, this.bounds.x1, this.bounds.y1) : this.bounds;
 
+	public virtual bool InsideBoundsOrIncluder(Vector2 mousePos) => this.InteractBounds().Inside(mousePos) || this.hoverRetained;
+
 	public virtual void UpdateScaleControls(Rect bounds) {
 		this.scaleControlExcluder = new Rect(
 			bounds.x0 + this.scaleControlInnerMargin,

--- a/FloodForge/src/popups/PopupManager.cs
+++ b/FloodForge/src/popups/PopupManager.cs
@@ -81,8 +81,16 @@ public static class PopupManager {
 			if (doResizeBoundsCheck)
 				popup.Translate(Vector2.Zero, false);
 			Mouse.Disabled = popup != mousePopup;
-			popup.Draw();
-			popup.FinishDraw();
+			try {
+				popup.Draw();
+				popup.FinishDraw();
+			}
+			catch (Exception e1) {
+				Logger.Error($"Problem encountered on popup with title {popup.popupTitle}({nameof(popup)}):\n{e1}");
+				popup.Close();
+				if (popup is not InfoPopup) // just in case InfoPopups have issues, we don't want to add more of them when one crashes.
+					Add($"Problem encountered on popup\n{popup.popupTitle}({nameof(popup)}):\n{e1.Message}\nview log.txt for further information");
+			}
 		}
 		doResizeBoundsCheck = false;
 		Mouse.Disabled = interactingPopup != null;

--- a/FloodForge/src/ui/MenuItems.cs
+++ b/FloodForge/src/ui/MenuItems.cs
@@ -30,7 +30,7 @@ public abstract class MenuItems {
 					PopupManager.Add(new InfoPopup(button.disabledInteractMessage));
 				}
 
-				if (!button.preventClose) this.selectedDropdownButton = null;
+				if (!button.preventClose && button.buttonEnabled) this.selectedDropdownButton = null;
 			}
 			return true;
 		}

--- a/FloodForge/src/ui/MenuItems.cs
+++ b/FloodForge/src/ui/MenuItems.cs
@@ -58,10 +58,14 @@ public abstract class MenuItems {
 				float y = Main.screenBounds.y - 0.1f;
 
 				float maxWidth = width;
+				int activeButtonsCount = 0;
 				foreach (Button button in dropdown.buttons) {
-					maxWidth = MathF.Max(maxWidth, button.Size.x + 0.02f);
+					if (button.buttonEnabled || Settings.DisabledButtonsMode.value != Settings.STDisabledButtonsMode.Hide) {
+						maxWidth = MathF.Max(maxWidth, button.Size.x + 0.02f);
+						activeButtonsCount++;
+					}
 				}
-				Rect extendedRect = Rect.FromSize(x - 0.01f, y + 0.05f, maxWidth + 0.02f, -0.05f * dropdown.buttons.Count - 0.01f);
+				Rect extendedRect = Rect.FromSize(x - 0.01f, y + 0.05f, maxWidth + 0.02f, -0.05f * activeButtonsCount - 0.01f);
 				this.selectedDropdownRect = extendedRect;
 
 				Immediate.Color(Themes.Popup);
@@ -74,7 +78,9 @@ public abstract class MenuItems {
 
 				foreach (Button button in dropdown.buttons) {
 					if (this.DrawButton(button, x, y)) {
-						y -= 0.05f;
+						if (button.buttonEnabled || Settings.DisabledButtonsMode.value != Settings.STDisabledButtonsMode.Hide ) {
+							y -= 0.05f;
+						}
 					}
 				}
 			}

--- a/FloodForge/src/ui/MenuItems.cs
+++ b/FloodForge/src/ui/MenuItems.cs
@@ -105,6 +105,11 @@ public abstract class MenuItems {
 
 				x += width + 0.01f;
 			}
+			else if (item is Divider) {
+				Immediate.Color(Themes.Border);
+				UI.Line(new (x, this.menuBarRect.y1 - 0.01f), new (x, this.menuBarRect.y1 - 0.05f));
+				x += 0.01f;
+			}
 		}
 		if ((Settings.DropdownOnHover || Mouse.JustLeft) && this.selectedDropdownButton != null && !(hoveringDropdownButton || this.selectedDropdownRect.Inside(Mouse.Pos))) {
 			this.selectedDropdownButton = null;
@@ -158,5 +163,9 @@ public abstract class MenuItems {
 			this.contextCheckCallback = contextCheckCallback;
 			this.disabledInteractMessage = disabledInteractMessage;
 		}
+	}
+
+	protected class Divider : UIItem {
+		public Divider() : base("") {}
 	}
 }

--- a/FloodForge/src/ui/MenuItems.cs
+++ b/FloodForge/src/ui/MenuItems.cs
@@ -18,11 +18,21 @@ public abstract class MenuItems {
 		}
 
 		if (button.buttonEnabled || Settings.DisabledButtonsMode.value != Settings.STDisabledButtonsMode.Hide ) {
-			UI.TextButtonMods mods = new UI.TextButtonMods();
-			if (button.Dark || (!button.buttonEnabled && Settings.DisabledButtonsMode.value == Settings.STDisabledButtonsMode.Grey)) {
-				mods.textColor = Themes.TextDisabled;
+			bool buttonDark = button.Dark || (!button.buttonEnabled && Settings.DisabledButtonsMode.value == Settings.STDisabledButtonsMode.Grey);
+			UI.ButtonResponse buttonResponse;
+			if (!button.useUITexture) {
+				UI.TextButtonMods mods = new UI.TextButtonMods();
+				if (buttonDark)
+					mods.textColor = Themes.TextDisabled;
+				buttonResponse = UI.TextButton(button.Text, Rect.FromSize(x, y, button.Size.x + 0.02f, 0.04f), mods);
 			}
-			if (UI.TextButton(button.Text, Rect.FromSize(x, y, button.Size.x + 0.02f, 0.04f), mods)) {
+			else {
+				UI.TextureButtonMods mods = new UI.TextureButtonMods();
+				if (buttonDark)
+					mods.textureColor = Themes.TextDisabled;
+				buttonResponse = UI.TextureButton(UVRect.FromSize(x, y, 0.04f, 0.04f).AtlasUV(button.Text), mods);
+			}
+			if (buttonResponse) {
 				if (button.buttonEnabled) {
 					button.onclick(button);
 				}
@@ -87,7 +97,7 @@ public abstract class MenuItems {
 
 			if (item is Button button1) {
 				if (this.DrawButton(button1, x, Main.screenBounds.y - 0.05f)) {
-					x += width + 0.01f;
+					x += button1.useUITexture ? 0.05f : (width + 0.01f);
 				}
 			}
 			else if (item is Dropdown dropdown1) {
@@ -147,6 +157,7 @@ public abstract class MenuItems {
 	}
 
 	protected class Button : UIItem {
+		public bool useUITexture = false;
 		public Action<Button> onclick;
 		public Func<Button, bool>? contextCheckCallback;
 		public bool buttonEnabled = true;
@@ -154,12 +165,13 @@ public abstract class MenuItems {
 		public virtual bool Dark => false;
 		public bool preventClose = false;
 
-		public Button(string text, Action<Button> callback) : base(text) {
+		public Button(string text, Action<Button> callback, bool useUITexture = false) : base(text) {
 			this.onclick = callback;
 			this.contextCheckCallback = null;
+			this.useUITexture = useUITexture;
 		}
 
-		public Button(string text, Action<Button> callback, Func<Button, bool> contextCheckCallback, string? disabledInteractMessage = null) : this(text, callback) {
+		public Button(string text, Action<Button> callback, Func<Button, bool> contextCheckCallback, string? disabledInteractMessage = null, bool useUITexture = false) : this(text, callback, useUITexture) {
 			this.contextCheckCallback = contextCheckCallback;
 			this.disabledInteractMessage = disabledInteractMessage;
 		}

--- a/FloodForge/src/ui/UI.cs
+++ b/FloodForge/src/ui/UI.cs
@@ -29,6 +29,7 @@ public static class UI {
 			new ("Cross",			new(0f,		0.25f,	0.25f,	0f		)),
 			new ("ArrowUp",			new(0.25f,	0.25f,	0.5f,	0f		)),
 			new ("RotateRight",		new(0.5f,	0.25f,	0.75f,	0f		)),
+			new ("RotateLeft",		new(0.75f,	0.25f,	0.5f,	0f		)),
 			new ("DotsHorizontal",	new(0.75f,	0.25f,	1f,		0f		)),
 			new ("Page",			new(0f,		0.5f,	0.25f,	0.25f	)),
 			new ("Folder",			new(0.25f,	0.5f,	0.5f,	0.25f	)),

--- a/FloodForge/src/world/WorldDraggable.cs
+++ b/FloodForge/src/world/WorldDraggable.cs
@@ -2,7 +2,7 @@ namespace FloodForge.World;
 
 public class WorldDraggable {
 	public bool Visible => this.IsVisible();
-	public virtual bool IsVisible() {
+	protected virtual bool IsVisible() {
 		return true;
 	}
 

--- a/FloodForge/src/world/WorldExporter.cs
+++ b/FloodForge/src/world/WorldExporter.cs
@@ -1,4 +1,4 @@
-using System.Text;
+using System.Diagnostics;
 using StbImageWriteSharp;
 using Stride.Core.Extensions;
 
@@ -305,9 +305,11 @@ public static class WorldExporter {
 	}
 
 	// TODO - make this a hundred times more compact (this is a naive implementation)
+	// My first attempt at making this more compact resulted in a slight performance loss, for some reason. Seems like this exporter is less fundamentally inefficient than I thought.
 	public static void ExportWorldFile() {
 		Logger.Info("Exporting world file");
 		
+		Stopwatch stopwatch = Stopwatch.StartNew();
 		ExportLog("");
 		ExportLog("========================================");
 
@@ -758,6 +760,8 @@ public static class WorldExporter {
 		ExportLog("End Exporter!");
 		ExportLog("========================================");
 		ExportLog("");
+		Logger.Info($"Elapsed time: {stopwatch.Elapsed.TotalMilliseconds}ms");
+		stopwatch.Stop();
 	}
 
 	public static string PreProcessorsToString(string[] preProcessorConditions) {

--- a/FloodForge/src/world/WorldParser.cs
+++ b/FloodForge/src/world/WorldParser.cs
@@ -1228,9 +1228,18 @@ public static class WorldParser {
 		}
 		WorldWindow.worldHistory.Clear();
 		RecentFiles.AddPath(worldPath);
+		
+		Logger.Info($"File path: {worldPath}");
+		string exportPath = PathUtil.Parent(worldPath);
+		if (Path.GetFileNameWithoutExtension(PathUtil.Parent(PathUtil.Parent(exportPath))).Equals("modify", StringComparison.InvariantCultureIgnoreCase)) {
+			message = $"Cannot load world from inside /modify folder";
+			Logger.Error(message);
+			return false;
+		}
+
 		roomAttractiveness.Clear();
 		WorldWindow.Reset();
-		WorldWindow.region.exportPath = PathUtil.Parent(worldPath);
+		WorldWindow.region.exportPath = exportPath;
 		WorldWindow.region.acronym = Path.GetFileNameWithoutExtension(worldPath);
 		WorldWindow.region.acronym = WorldWindow.region.acronym[(WorldWindow.region.acronym.IndexOfReverse('_') + 1)..];
 

--- a/FloodForge/src/world/WorldParser.cs
+++ b/FloodForge/src/world/WorldParser.cs
@@ -1218,10 +1218,12 @@ public static class WorldParser {
 		return displaynamePath == null ? "" : File.ReadAllText(displaynamePath).Trim();
 	}
 
-	public static bool ImportWorldFile(string worldPath) {
+	public static bool ImportWorldFile(string worldPath, out string? message) {
+		message = null;
 		WorldWindow.importIncomplete = true;
 		if (!File.Exists(worldPath)) {
-			Logger.Error("Cannot find world_XX.txt");
+			message = "Cannot find world_XX.txt";
+			Logger.Error(message);
 			return false;
 		}
 		WorldWindow.worldHistory.Clear();
@@ -1263,7 +1265,10 @@ public static class WorldParser {
 				}
 			}
 
-			Logger.Info(string.Join(", ", WorldWindow.region.regionsPaths));
+			if(WorldWindow.region.regionsPaths.Count != 0)
+				Logger.Info(string.Join(", ", WorldWindow.region.regionsPaths));
+			else
+				Logger.Info("'No regions.txt paths found");
 		}
 
 		WorldWindow.region.acronym = WorldWindow.region.FindAcronym(WorldWindow.region.acronym);
@@ -1273,7 +1278,8 @@ public static class WorldParser {
 		string? roomsPath = PathUtil.FindDirectory(PathUtil.Parent(WorldWindow.region.exportPath), WorldWindow.region.acronym + "-rooms");
 		Logger.Info($"RoomsPath: {roomsPath ?? "NULL"}");
 		if (roomsPath == null || roomsPath == "") {
-			Logger.Error("Cannot find rooms directory");
+			message = "Cannot find rooms directory";
+			Logger.Error(message);
 			return false;
 		}
 		WorldWindow.region.roomsPath = roomsPath;
@@ -1281,7 +1287,7 @@ public static class WorldParser {
 		string? propertiesPath = PathUtil.FindFile(WorldWindow.region.exportPath, "properties.txt");
 		if (propertiesPath != null) {
 			Logger.Info("Loading properties");
-			if (!ParseProperties(propertiesPath)) return false;
+			if (!ParseProperties(propertiesPath)) return false; // Does ParseProperties at any point even have the capacity to return false??
 		}
 
 		Logger.Info("Loading world");

--- a/FloodForge/src/world/WorldParser.cs
+++ b/FloodForge/src/world/WorldParser.cs
@@ -1220,13 +1220,11 @@ public static class WorldParser {
 
 	public static bool ImportWorldFile(string worldPath, out string? message) {
 		message = null;
-		WorldWindow.importIncomplete = true;
 		if (!File.Exists(worldPath)) {
 			message = "Cannot find world_XX.txt";
 			Logger.Error(message);
 			return false;
 		}
-		WorldWindow.worldHistory.Clear();
 		RecentFiles.AddPath(worldPath);
 		
 		Logger.Info($"File path: {worldPath}");
@@ -1236,6 +1234,8 @@ public static class WorldParser {
 			Logger.Error(message);
 			return false;
 		}
+		WorldWindow.importIncomplete = true;
+		WorldWindow.worldHistory.Clear();
 
 		roomAttractiveness.Clear();
 		WorldWindow.Reset();

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -42,7 +42,8 @@ public static class WorldWindow {
 	public static Region region = null!;
 	// public static List<ConnectionVisual> virtualConnections = [];
 	public static List<Connection> connectionsToBeRemoved = [];
-	public static bool ValidRegionLoaded => !(WorldWindow.region == null || WorldWindow.region.acronym.IsNullOrEmpty() || WorldWindow.region.exportPath.IsNullOrEmpty() || importIncomplete);
+	public static bool HasExportPath => !WorldWindow.region.exportPath.IsNullOrEmpty();
+	public static bool ValidRegionLoaded => !(WorldWindow.region == null || WorldWindow.region.acronym.IsNullOrEmpty() || !HasExportPath || importIncomplete);
 	public static bool importIncomplete = false;
 	public static bool invalidCreaturesEncountered = false;
 	public static bool ExportFinished = true;
@@ -1001,7 +1002,7 @@ public static class WorldWindow {
 			if (region.acronym.IsNullOrEmpty()) {
 				PopupManager.Add(new InfoPopup("You must create or import your region\nbefore creating or editing a room."));
 			}
-			else if (region.exportPath.IsNullOrEmpty()) {
+			else if (!HasExportPath) {
 				PopupManager.Add(new InfoPopup("You must export your region\nbefore creating or editing a room."));
 			}
 			else {
@@ -1913,7 +1914,7 @@ public static class WorldWindow {
 			acronym = filename.Split('_')[0];
 		else
 			acronym = "";
-		if ((acronym.Equals(region.acronym, StringComparison.InvariantCultureIgnoreCase) & !acronym.IsNullOrEmpty()) || region.exportPath.IsNullOrEmpty()) {
+		if ((acronym.Equals(region.acronym, StringComparison.InvariantCultureIgnoreCase) & !acronym.IsNullOrEmpty()) && HasExportPath) {
 			return CreateAndAddRoom(path, filename);
 		}
 		else {

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -1264,6 +1264,10 @@ public static class WorldWindow {
 					continue;
 				bool isLoop = roomA == roomB && connection.roomAExitID == connection.roomBExitID;
 				FreeConnection freeConnection = new(isLoop) { drawStriped = true };
+
+				bool draggableAIsVisible = connection.roomA == replaceRoom.replacedRoom ? replaceRoom.Visible : connection.roomA.Visible;
+				bool draggableBIsVisible = connection.roomB == replaceRoom.replacedRoom ? replaceRoom.Visible : connection.roomB.Visible;
+				freeConnection.SetVisibilities(draggableAIsVisible, draggableBIsVisible, connection.ConnectionVisible);
 				freeConnection.Draw(roomA.GetConnectionConnectPoint(connection.roomAExitID, roomAPosition), roomB.GetConnectionConnectPoint(connection.roomBExitID, roomBPosition), roomA.GetConnectionConnectDirection(connection.roomAExitID), roomB.GetConnectionConnectDirection(connection.roomBExitID), Themes.RoomConnection, isLoop);
 			}
 		}

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -2003,6 +2003,8 @@ public static class WorldWindow {
 
 			WorldExporter.ExportDisplayName(PathUtil.FindOrAssumeFile(WorldWindow.region.exportPath, "displayname.txt"));
 
+			RecentFiles.AddPath(PathUtil.FindOrAssumeFile(WorldWindow.region.exportPath, $"world_{WorldWindow.region.acronym}.txt"));
+
 			PersistentData.StorePersistentData(WorldWindow.region.acronym);
 			PopupManager.Add(new InfoPopup("Exported successfully!"));
 			WorldWindow.ExportFinished = true;

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -1083,6 +1083,7 @@ public static class WorldWindow {
 		Vector2 gridScale = Main.screenBounds * (gridStep * 16f);
 
 		Immediate.Color(Themes.Grid);
+		Program.gl.Enable(EnableCap.Blend);
 		Immediate.Begin(Immediate.PrimitiveType.LINES);
 		for (float x = -gridScale.x + offset.x; x < gridScale.x + offset.x; x += gridStep) {
 			Immediate.Vertex(x + extraOffset.x, -cameraScale * Main.screenBounds.y + offset.y + extraOffset.y - gridStep);
@@ -1092,13 +1093,15 @@ public static class WorldWindow {
 			Immediate.Vertex(-cameraScale * Main.screenBounds.x + offset.x + extraOffset.x - gridStep, y + extraOffset.y);
 			Immediate.Vertex(cameraScale * Main.screenBounds.x + offset.x + extraOffset.x + gridStep, y + extraOffset.y);
 		}
-		Immediate.Color(Themes.Layer1Color);
+		Immediate.Color(Themes.RoomAir);
+		Immediate.Alpha(0.25f);
 		Immediate.Vertex(cameraOffset.x - Main.screenBounds.x * cameraScale, -(cameraOffset.y * (1 - 1f)) / 2); // this may be another colorpopup situation
 		Immediate.Vertex(cameraOffset.x + Main.screenBounds.x * cameraScale, -(cameraOffset.y * (1 - 1f)) / 2);
-		Immediate.Color(Themes.Layer1Color);
 		Immediate.Vertex(-(cameraOffset.x * 0) / 2, cameraOffset.y - Main.screenBounds.y * cameraScale);
 		Immediate.Vertex(-(cameraOffset.x * 0) / 2, cameraOffset.y + Main.screenBounds.y * cameraScale);
 		Immediate.End();
+		Immediate.Alpha(1f);
+		Program.gl.Disable(EnableCap.Blend);
 	}
 
 	private static void DrawCurrentConnection() {

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -2019,6 +2019,7 @@ public static class WorldWindow {
 				new Button("New", button => {
 					PopupManager.Add(new AcronymPopup((acronym) => {
 							WorldWindow.Reset();
+							WorldWindow.importIncomplete = false;
 							WorldWindow.region.offscreenDen = new OffscreenRoom("offscreenden" + acronym.ToLowerInvariant(), "OffscreenDen" + acronym.ToUpperInvariant());
 							WorldWindow.region.rooms.Add(WorldWindow.region.offscreenDen);
 							WorldWindow.region.acronym = acronym;
@@ -2042,7 +2043,7 @@ public static class WorldWindow {
 							ExportButton();
 						}
 						else{
-							PopupManager.Add(new ConfirmPopup("This region contains invalid dens!\nExporting may delete or change these dens.").SetOkay("Export anyway").Okay(ExportButton));
+							PopupManager.Add(new ConfirmPopup("This region contains invalid dens!\nExporting may delete or change these dens.").SetOkay("Export anyway").Okay(() => { WorldWindow.ExportFinished = false; ExportButton(); }));
 						}
 					},
 					button => {

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -1990,7 +1990,7 @@ public static class WorldWindow {
 			}
 
 			if (!lastExportDirectory.IsNullOrEmpty()) {
-				Logger.Info($"Set exportPath from\n{WorldWindow.region.exportPath}\nback to\b{lastExportDirectory}");
+				Logger.Info($"Set exportPath from\n{WorldWindow.region.exportPath}\nback to\n{lastExportDirectory}");
 				WorldWindow.region.exportPath = lastExportDirectory;
 			}
 		}

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -2022,8 +2022,8 @@ public static class WorldWindow {
 					PopupManager.Add(new FilesystemPopup(selection => {
 						if (selection.Length == 0) return;
 
-						if (!WorldParser.ImportWorldFile(selection[0]))
-							PopupManager.Add(new InfoPopup("Importing world failed!\nView log.txt for more info."));
+						if (!WorldParser.ImportWorldFile(selection[0], out string? message))
+							PopupManager.Add(new InfoPopup($"Importing world failed!\n{(message == null ? "" : $"{message}\n")}View log.txt for more info."));
 					}, 0).Filter(Regexs.WorldFileRegex()).Hint("world_xx.txt"));
 				}),
 
@@ -2095,8 +2095,8 @@ public static class WorldWindow {
 							PopupManager.Add(new InfoPopup("Could not find world_xx.txt file!"));
 							return;
 						}
-						if (!WorldParser.ImportWorldFile(path))
-							PopupManager.Add(new InfoPopup("Importing world failed!\nView log.txt for more info."));
+						if (!WorldParser.ImportWorldFile(path, out string? message))
+						PopupManager.Add(new InfoPopup($"Importing world failed!\n{(message == null ? "" : $"{message}\n")}View log.txt for more info."));
 					}, button => { return WorldWindow.ValidRegionLoaded; },
 					"You must create or import a region\nbefore refreshing."),
 				]),

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -1956,11 +1956,13 @@ public static class WorldWindow {
 					Directory.CreateDirectory("worlds");
 				}
 				WorldWindow.region.exportPath = PathUtil.FindOrAssumeDirectory("worlds", WorldWindow.region.acronym);
+				WorldWindow.region.roomsPath = PathUtil.FindOrAssumeDirectory("worlds", $"{WorldWindow.region.acronym}-rooms");
 				Logger.Info($"Special exporting to directory: {WorldWindow.region.exportPath}");
 
-				if (!Directory.Exists(WorldWindow.region.exportPath)) {
+				if (!Directory.Exists(WorldWindow.region.exportPath))
 					Directory.CreateDirectory(WorldWindow.region.exportPath);
-				}
+				if (!Directory.Exists(WorldWindow.region.roomsPath))
+					Directory.CreateDirectory(WorldWindow.region.roomsPath);
 			}
 
 			if (!string.IsNullOrEmpty(WorldWindow.region.exportPath)) {

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -1996,6 +1996,7 @@ public static class WorldWindow {
 		}
 
 		private static void ExportMap() {
+			bool isNewMap = !WorldWindow.HasExportPath;
 			WorldWindow.invalidCreaturesEncountered = false;
 			WorldExporter.ExportMapFile();
 			WorldExporter.ExportWorldFile();
@@ -2007,7 +2008,8 @@ public static class WorldWindow {
 
 			WorldExporter.ExportDisplayName(PathUtil.FindOrAssumeFile(WorldWindow.region.exportPath, "displayname.txt"));
 
-			RecentFiles.AddPath(PathUtil.FindOrAssumeFile(WorldWindow.region.exportPath, $"world_{WorldWindow.region.acronym}.txt"));
+			if (isNewMap)
+				RecentFiles.AddPath(PathUtil.FindOrAssumeFile(WorldWindow.region.exportPath, $"world_{WorldWindow.region.acronym}.txt"));
 
 			PersistentData.StorePersistentData(WorldWindow.region.acronym);
 			PopupManager.Add(new InfoPopup("Exported successfully!"));

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -1991,7 +1991,7 @@ public static class WorldWindow {
 						ExportMap();
 					}, 0)
 					.Filter(FilesystemPopup.SelectionType.Folder)
-					.Hint("YOUR_MOD/world/")
+					.Hint("YOUR_MOD/world/").ButtonText("Export")
 				);
 			}
 
@@ -2068,6 +2068,7 @@ public static class WorldWindow {
 									.Filter(new Regex("((?!.*_settings)(?=.+_.+).+\\.txt)|(gate_([^._-]+)_([^._-]+)\\.txt)"))
 									.Multiple()
 									.Hint("xx_a01.txt")
+									.ButtonText("Add Room")
 							);
 						},
 						button => {
@@ -2101,7 +2102,7 @@ public static class WorldWindow {
 								referenceImages.Add(newImage);
 								selectedDraggables.Add(newImage);
 							}
-						}));
+						})).Hint("map_concept.png").ButtonText("Add");
 					}, button => {
 						return WorldWindow.ValidRegionLoaded;
 					}),

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -22,6 +22,7 @@ public static class WorldWindow {
 	private static readonly WorldMenuItems menuItems = new WorldMenuItems();
 	private static FloodforgeConfigPopup configPopup = new FloodforgeConfigPopup();
 
+	public static bool VisibleAxisLines { get; private set; } = true;
 	public static bool VisibleDevItems { get; private set; } = false;
 	public static bool VisibleCreatures { get; private set; } = true;
 	public static bool VisibleTimelineIcons { get; private set; } = true;
@@ -1094,14 +1095,16 @@ public static class WorldWindow {
 			Immediate.Vertex(-cameraScale * Main.screenBounds.x + offset.x + extraOffset.x - gridStep, y + extraOffset.y);
 			Immediate.Vertex(cameraScale * Main.screenBounds.x + offset.x + extraOffset.x + gridStep, y + extraOffset.y);
 		}
-		Immediate.Color(Themes.RoomAir);
-		Immediate.Alpha(0.25f);
-		Immediate.Vertex(cameraOffset.x - Main.screenBounds.x * cameraScale, -(cameraOffset.y * (1 - 1f)) / 2); // this may be another colorpopup situation
-		Immediate.Vertex(cameraOffset.x + Main.screenBounds.x * cameraScale, -(cameraOffset.y * (1 - 1f)) / 2);
-		Immediate.Vertex(-(cameraOffset.x * 0) / 2, cameraOffset.y - Main.screenBounds.y * cameraScale);
-		Immediate.Vertex(-(cameraOffset.x * 0) / 2, cameraOffset.y + Main.screenBounds.y * cameraScale);
+		if (VisibleAxisLines) {
+			Immediate.Color(Themes.RoomAir);
+			Immediate.Alpha(0.25f);
+			Immediate.Vertex(cameraOffset.x - Main.screenBounds.x * cameraScale, -(cameraOffset.y * (1 - 1f)) / 2); // this may be another colorpopup situation
+			Immediate.Vertex(cameraOffset.x + Main.screenBounds.x * cameraScale, -(cameraOffset.y * (1 - 1f)) / 2);
+			Immediate.Vertex(-(cameraOffset.x * 0) / 2, cameraOffset.y - Main.screenBounds.y * cameraScale);
+			Immediate.Vertex(-(cameraOffset.x * 0) / 2, cameraOffset.y + Main.screenBounds.y * cameraScale);
+			Immediate.Alpha(1f);
+		}
 		Immediate.End();
-		Immediate.Alpha(1f);
 		Program.gl.Disable(EnableCap.Blend);
 	}
 
@@ -2163,6 +2166,11 @@ public static class WorldWindow {
 							return WorldWindow.ValidRegionLoaded;
 						}
 					),
+
+					new Button("Axis Lines: Shown", button => {
+						VisibleAxisLines = !VisibleAxisLines;
+						button.Text = VisibleAxisLines ? "Axis Lines: Shown" : "Axis Lines: Hidden";
+					}, button => { return WorldWindow.ValidRegionLoaded; }) { preventClose = true },
 
 					new Button("Dev Items: Hidden", button => {
 						VisibleDevItems = !VisibleDevItems;

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -2097,6 +2097,7 @@ public static class WorldWindow {
 						string? path = PathUtil.FindFile(WorldWindow.region.exportPath, $"world_{WorldWindow.region.acronym}.txt");
 						if (path == null) {
 							PopupManager.Add(new InfoPopup("Could not find world_xx.txt file!"));
+							Logger.Info($"Failed to find world file at {WorldWindow.region.exportPath}/world_{WorldWindow.region.acronym}.txt");
 							return;
 						}
 						if (!WorldParser.ImportWorldFile(path, out string? message))

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -20,7 +20,6 @@ internal static partial class Regexs {
 
 public static class WorldWindow {
 	private static readonly WorldMenuItems menuItems = new WorldMenuItems();
-	private static FloodforgeConfigPopup configPopup = new FloodforgeConfigPopup();
 
 	public static bool VisibleAxisLines { get; private set; } = true;
 	public static bool VisibleDevItems { get; private set; } = false;
@@ -2247,7 +2246,7 @@ public static class WorldWindow {
 				}, b => worldHistory.HasRedos),
 
 				new Button("Settings", button => {
-					PopupManager.Add(configPopup, true);
+					PopupManager.Add(new FloodforgeConfigPopup(), true);
 				})
 			];
 		}

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -1988,7 +1988,10 @@ public static class WorldWindow {
 				);
 			}
 
-			WorldWindow.region.exportPath = lastExportDirectory;
+			if (!lastExportDirectory.IsNullOrEmpty()) {
+				Logger.Info($"Set exportPath from\n{WorldWindow.region.exportPath}\nback to\b{lastExportDirectory}");
+				WorldWindow.region.exportPath = lastExportDirectory;
+			}
 		}
 
 		private static void ExportMap() {

--- a/FloodForge/src/world/WorldWindow.cs
+++ b/FloodForge/src/world/WorldWindow.cs
@@ -2237,13 +2237,19 @@ public static class WorldWindow {
 					})
 				]),
 
-				new Button("<", button => {
+				new Divider(),
+				// UNDO
+				new Button("RotateLeft", button => {
 					worldHistory.Undo();
-				}, b => worldHistory.HasUndos),
+				}, b => worldHistory.HasUndos) { useUITexture = true },
 
-				new Button(">", button => {
+				new Divider(),
+				// REDO
+				new Button("RotateRight", button => {
 					worldHistory.Redo();
-				}, b => worldHistory.HasRedos),
+				}, b => worldHistory.HasRedos) { useUITexture = true },
+
+				new Divider(),
 
 				new Button("Settings", button => {
 					PopupManager.Add(new FloodforgeConfigPopup(), true);

--- a/FloodForge/src/world/connections/Connection.cs
+++ b/FloodForge/src/world/connections/Connection.cs
@@ -12,9 +12,8 @@ public class Connection : ConnectionVisual{
 	public override Vector2 PointB => this.roomB.GetConnectionConnectPoint(this.roomBExitID);
 	public override Vector2i DirectionB => this.roomB.GetConnectionConnectDirection(this.roomBExitID);
 
-	private bool VisibleTimelineIsEmptyOnly => WorldWindow.VisibleTimeline.timelineType == TimelineType.Only && WorldWindow.VisibleTimeline.timelines.Count == 0;
-	public override bool AVisible => WorldWindow.VisibleLayers[this.roomA.data.layer] && (this.VisibleTimelineIsEmptyOnly || WorldWindow.VisibleTimeline.OverlapsWith(this.roomA.timeline) || this.ConnectionVisible);
-	public override bool BVisible => WorldWindow.VisibleLayers[this.roomB.data.layer] && (this.VisibleTimelineIsEmptyOnly || WorldWindow.VisibleTimeline.OverlapsWith(this.roomB.timeline) || this.ConnectionVisible);
+	public override bool AVisible => this.roomA.Visible;
+	public override bool BVisible => this.roomB.Visible;
 
 	public string[] preProcessorConditions = [];
 	

--- a/FloodForge/src/world/connections/FreeConnection.cs
+++ b/FloodForge/src/world/connections/FreeConnection.cs
@@ -14,6 +14,33 @@ public class FreeConnection : ConnectionVisual {
 
 	protected Color color;
 
+	protected bool aVisible = true;
+	public override bool AVisible {
+		get {
+			return this.aVisible;
+		}
+	}
+
+	protected bool bVisible = true;
+	public override bool BVisible {
+		get {
+			return this.bVisible;
+		}
+	}
+
+	protected bool connectionVisible = true;
+	public override bool ConnectionVisible {
+		get {
+			return this.connectionVisible;
+		}
+	}
+
+	public void SetVisibilities(bool a, bool b, bool connection) {
+		this.aVisible = a;
+		this.bVisible = b;
+		this.connectionVisible = connection;
+	}
+
 	protected override (Color, Color) GetColorInformation(bool fadeMiddle, bool AVisible, bool BVisible, bool hovered) {
 		Color colorA = this.color;
 		Color colorB = this.color;

--- a/FloodForge/src/world/draggables/ReplaceRoom.cs
+++ b/FloodForge/src/world/draggables/ReplaceRoom.cs
@@ -13,8 +13,8 @@ public class ReplaceRoom : MapDraggable {
 
     public Vector2i size;
 
-	public override bool IsVisible() {
-		return WorldWindow.VisibleTimeline.OverlapsWith(this.timeline);
+	protected override bool IsVisible() {
+		return WorldWindow.VisibleTimeline.OverlapsWith(this.timeline) && !this.IsHidden;
 	}
 
 	public ReplaceRoom(Room replacingRoom, Room replacedRoom, Timeline replacingTimeline, string[] preProcessorConditions) {

--- a/FloodForge/src/world/popups/ModularPopups/RoomSettingsPopup.cs
+++ b/FloodForge/src/world/popups/ModularPopups/RoomSettingsPopup.cs
@@ -307,7 +307,7 @@ public class RoomSettingsPopup : ModularPopup {
 		}
 
 		private void OpenFileSystem() {
-			PopupManager.Add(new FilesystemPopup(this.SelectFile, 1).Hint("xx_a01_future.txt").Filter(new Regex("((?!.*_settings)(?=.+_.+).+\\.txt)|(gate_([^._-]+)_([^._-]+)\\.txt)")).Title("Select room file to use"), true);
+			PopupManager.Add(new FilesystemPopup(this.SelectFile, 1).Hint("xx_a01_future.txt").Filter(new Regex("((?!.*_settings)(?=.+_.+).+\\.txt)|(gate_([^._-]+)_([^._-]+)\\.txt)")).ButtonText("Select").Title("Select room file to use"), true);
 		}
 
 		private void SelectFile(string[] selectedFileArray) {

--- a/FloodForge/src/world/popups/SplashArtPopup.cs
+++ b/FloodForge/src/world/popups/SplashArtPopup.cs
@@ -244,8 +244,8 @@ public class SplashArtPopup : Popup {
 
 				if (Mouse.JustLeft) {
 					this.Close();
-					if (!WorldParser.ImportWorldFile(RecentFiles.recents[i]))
-						PopupManager.Add(new InfoPopup("Importing world failed!\nView log.txt for more info."));
+					if (!WorldParser.ImportWorldFile(RecentFiles.recents[i], out string? message))
+						PopupManager.Add(new InfoPopup($"Importing world failed!\n{(message == null ? "" : $"{message}\n")}View log.txt for more info."));
 					else if (!Settings.HideTutorial && !Settings.HideTutorialOnLoadWorld && this.showTutorialAfterClose) {
 						PopupManager.Add(new MarkdownPopup("docs/TutorialWorld.md"));
 					}

--- a/FloodForge/src/world/room/Room.cs
+++ b/FloodForge/src/world/room/Room.cs
@@ -56,7 +56,7 @@ public class Room : MapDraggable {
 	private int specialExitCount = 0;
 	public int GarbageWormDenIndex => this.specialExitCount + this.nonDenExitCount + this.denShortcutEntrances.Count;
 
-	public override bool IsVisible() {
+	protected override bool IsVisible() {
 		return WorldWindow.VisibleLayers[this.data.layer] && this.timeline.OverlapsWith(WorldWindow.VisibleTimeline);
 	}
 

--- a/FloodForge/src/world/room/Room.cs
+++ b/FloodForge/src/world/room/Room.cs
@@ -57,7 +57,7 @@ public class Room : MapDraggable {
 	public int GarbageWormDenIndex => this.specialExitCount + this.nonDenExitCount + this.denShortcutEntrances.Count;
 
 	protected override bool IsVisible() {
-		return WorldWindow.VisibleLayers[this.data.layer] && this.timeline.OverlapsWith(WorldWindow.VisibleTimeline);
+		return this.CheckTimelineCull();
 	}
 
 	// REVIEW - check for redundancy in terms of edge-case checks


### PR DESCRIPTION
- Reduced grid center line strength, added toggle to show/hide "Axis Lines" under "View" dropdown
- Added warning to FloodForgeConfigPopup about the fact that it does not save anything (yet).
- Fixed FloodForgeConfigPopup doing really weird stuff to the cursor image
- Added error management to popup drawing, improve popup problem logging (in an attempt to be able to debug an as of yet unsolved issue regarding filesystempopups and empty selections)
- Added error message when trying to load a world that exists in a Modify folder (Encountered by a Raincord member)
- Fixed the XX-rooms folder not being created when exporting into the floodforge/worlds folder
- Fixed exported new regions not being saved to regions
- Fixed dropdowns closing when clicking on disabled buttons
- Fixed dropdowns having empty spaces if DisabledButtonsMode is set to Hide
- Fixed several issues related to newly created regions not knowing that they are valid
- Fixed similar issues related to trying to load a new region after failing to load due to the aforementioned modify load error thing
- Fixed replaceRoom virtual connections annoyingly always being visible ([Reported by Windy](https://discord.com/channels/1363582432967790682/1536714451540123771/1536714451540123771))
- Fixed regular connections not fading/hiding properly when rooms hide themselves due to replacing rooms
- Fixed replaceRooms being counted as visible and draggable while hidden
- Changed redo/undo buttons to be clearer by using actual images instead of the "<" and ">" characters
- Fixed scrolling inside a popup affecting droplet's camera zoom ([Reported by Windy](https://discord.com/channels/1363582432967790682/1536714451540123771/1537076023345287289))
- Fixed an edge case where you could draw a single tile when resizing from the grace area outside a popup in droplet
- Fixed two cases where popup bounds checks did not take into account reduced width while collapsed
- Fixed exported Rained projects crashing Drizzle ([Also reported by Windy](https://discord.com/channels/1363582432967790682/1536714451540123771/1537101130675519600))
- Fixed exported Rained projects having incorrect camera positions
- Added context-specific text for the Filesystempopup's "open" button (I.E. "Import", "Add Room")